### PR TITLE
Add GitHub Actions workflow for dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: 'Dependency review'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4


### PR DESCRIPTION
- Introduce a new GitHub Actions workflow to perform dependency reviews on push and pull request events targeting the main branch.
- Utilize the `actions/checkout@v4` action to check out the repository.
- Use the `actions/dependency-review-action@v4` action to perform the dependency review.