### PR TITLE
Add dependency review workflow and update Dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly" # How often to check for updates

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,8 +1,6 @@
 name: 'Dependency review'
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
- Introduce a GitHub Actions workflow to perform dependency reviews on pull request events targeting the main branch.
- Utilize the `actions/checkout@v4` and `actions/dependency-review-action@v4` actions.
- Update Dependabot configuration to check for Gradle dependency updates on a weekly interval.

Changes to be committed:
modified:   .github/dependabot.yml
modified:   .github/workflows/dependency-review.yml