### PR TITLE
Update dependency-review.yml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,8 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@v4
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+#      - name: 'Checkout repository'
+#        uses: actions/checkout@v4
+#      - name: 'Dependency Review'
+#        uses: actions/dependency-review-action@v4
+      - run: echo "Empty action, because the dependency-review-action is only available for private repos with a GitHub Advanced Security license."

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,8 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
+# The following steps are commented out because the dependency-review-action
+# is only available for private repositories with a GitHub Advanced Security license.
 #      - name: 'Checkout repository'
 #        uses: actions/checkout@v4
 #      - name: 'Dependency Review'


### PR DESCRIPTION
Comment actions out, because the dependency-review-action is only available for private repos with a GitHub Advanced Security license.