### PR TITLE
Update at 2026-02-02-07-24

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,4 +21,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build

--- a/.github/workflows/jars.yml
+++ b/.github/workflows/jars.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle Wrapper
-        run: ./gradlew jar
+        run: |
+          chmod +x ./gradlew
+          ./gradlew jar
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for building the project with Gradle. The main improvement is ensuring that the `gradlew` script has executable permissions before running it, which increases reliability in CI environments.

**Workflow reliability improvements:**

* Added a `chmod +x ./gradlew` step before executing Gradle commands in `.github/workflows/gradle.yml` to ensure the wrapper script is executable.
* Added a `chmod +x ./gradlew` step before executing Gradle commands in `.github/workflows/jars.yml` to prevent permission issues during the build process.